### PR TITLE
feat: multi-language symbol/call/route heuristics

### DIFF
--- a/repotrace/deps.py
+++ b/repotrace/deps.py
@@ -1,12 +1,34 @@
-"""Import graph, cycle detection, and architectural checks."""
+"""Language-agnostic import graph, cycle detection, and architectural checks."""
 
 from __future__ import annotations
 
 from collections import defaultdict
-from pathlib import Path
+from pathlib import PurePosixPath, Path
 from typing import Iterable
 
 from . import db
+
+CODE_LANGUAGES = {
+    "python",
+    "javascript",
+    "typescript",
+    "go",
+    "rust",
+    "java",
+    "kotlin",
+    "swift",
+    "c",
+    "cpp",
+    "csharp",
+    "ruby",
+    "php",
+}
+
+JS_TS_EXTS = (".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs")
+RUST_EXTS = (".rs",)
+RUBY_EXTS = (".rb",)
+PHP_EXTS = (".php",)
+C_EXTS = (".h", ".hpp", ".hh", ".hxx", ".c", ".cc", ".cpp", ".cxx")
 
 
 def _is_python(path: str) -> bool:
@@ -15,20 +37,80 @@ def _is_python(path: str) -> bool:
 
 def _is_test_file(path: str) -> bool:
     name = Path(path).name
-    return path.startswith("tests/") or "/tests/" in path or name.startswith("test_")
+    return (
+        path.startswith("tests/")
+        or "/tests/" in path
+        or name.startswith("test_")
+        or name.endswith("_test.go")
+        or name.endswith(".test.js")
+        or name.endswith(".test.jsx")
+        or name.endswith(".test.ts")
+        or name.endswith(".test.tsx")
+        or name.endswith(".spec.js")
+        or name.endswith(".spec.jsx")
+        or name.endswith(".spec.ts")
+        or name.endswith(".spec.tsx")
+        or "/src/test/" in path
+        or "/__tests__/" in path
+    )
 
 
-def _module_for_path(path: str) -> str | None:
-    if not _is_python(path):
-        return None
-    stem = path.rsplit(".", 1)[0].replace("/", ".")
-    if stem.endswith(".__init__"):
-        return stem[: -len(".__init__")]
+def _strip_suffix(path: str) -> str:
+    return path.rsplit(".", 1)[0] if "." in Path(path).name else path
+
+
+def _without_common_source_root(stem: str) -> str:
+    prefixes = (
+        "src/main/java/",
+        "src/test/java/",
+        "src/main/kotlin/",
+        "src/test/kotlin/",
+        "app/src/main/java/",
+        "app/src/test/java/",
+        "app/src/main/kotlin/",
+        "app/src/test/kotlin/",
+        "Sources/",
+        "Tests/",
+        "src/",
+    )
+    for prefix in prefixes:
+        if stem.startswith(prefix):
+            return stem[len(prefix) :]
     return stem
 
 
+def _module_for_path(path: str, language: str | None = None) -> str | None:
+    if language == "python" or (language is None and _is_python(path)):
+        stem = path.rsplit(".", 1)[0].replace("/", ".")
+        if stem.endswith(".__init__"):
+            return stem[: -len(".__init__")]
+        return stem
+
+    stem = _strip_suffix(path)
+    if language in {"javascript", "typescript"}:
+        if stem.endswith("/index"):
+            stem = stem[: -len("/index")]
+        return stem.replace("/", ".")
+    if language == "go":
+        parent = str(PurePosixPath(path).parent)
+        return "" if parent == "." else parent
+    if language == "rust":
+        if path in {"src/lib.rs", "src/main.rs"}:
+            return "crate"
+        if stem.endswith("/mod"):
+            stem = stem[: -len("/mod")]
+        if stem.startswith("src/"):
+            stem = stem[len("src/") :]
+        return stem.replace("/", "::")
+    if language in {"java", "kotlin", "swift", "csharp", "php"}:
+        return _without_common_source_root(stem).replace("/", ".").replace("\\", ".")
+    if language in {"c", "cpp", "ruby"}:
+        return stem.replace("/", ".")
+    return None
+
+
 def _package_for_path(path: str) -> str:
-    module = _module_for_path(path) or ""
+    module = _module_for_path(path, "python") or ""
     if path.endswith("/__init__.py"):
         return module
     return module.rsplit(".", 1)[0] if "." in module else ""
@@ -56,38 +138,228 @@ def _resolve_absolute(module: str, imported_name: str | None) -> list[str]:
     return candidates
 
 
-def _best_module_match(candidates: Iterable[str], module_to_path: dict[str, str]) -> str | None:
+def _best_module_match(candidates: Iterable[str], module_to_paths: dict[str, list[str]]) -> str | None:
     matches: list[str] = []
     for candidate in candidates:
-        parts = candidate.split(".")
+        cleaned = candidate.strip().strip(";").replace("::", ".").replace("/", ".")
+        if cleaned.endswith(".*"):
+            cleaned = cleaned[: -len(".*")]
+        parts = cleaned.split(".")
         for i in range(len(parts), 0, -1):
             prefix = ".".join(parts[:i])
-            if prefix in module_to_path:
+            if prefix in module_to_paths:
                 matches.append(prefix)
     if not matches:
         return None
     return max(matches, key=lambda m: (m.count("."), len(m)))
 
 
+def _normalize_posix(path: PurePosixPath | str) -> str:
+    return str(PurePosixPath(str(path)))
+
+
+def _first_existing(candidates: Iterable[str], files_by_path: dict[str, dict]) -> str | None:
+    for candidate in candidates:
+        normalized = _normalize_posix(candidate)
+        if normalized in files_by_path:
+            return normalized
+    return None
+
+
+def _resolve_path_like(
+    source_path: str,
+    module: str,
+    files_by_path: dict[str, dict],
+    extensions: Iterable[str],
+    *,
+    relative_to_source: bool = True,
+) -> str | None:
+    spec = module.strip().strip("'").strip('"')
+    if not spec:
+        return None
+    bases: list[PurePosixPath] = []
+    spec_path = PurePosixPath(spec)
+    if relative_to_source and spec.startswith("."):
+        bases.append(PurePosixPath(source_path).parent / spec_path)
+    bases.append(spec_path)
+
+    candidates: list[str] = []
+    for base in bases:
+        candidates.append(str(base))
+        for ext in extensions:
+            candidates.append(str(base) + ext)
+        for ext in extensions:
+            candidates.append(str(base / ("index" + ext)))
+            candidates.append(str(base / ("mod" + ext)))
+    return _first_existing(candidates, files_by_path)
+
+
+def _representative_file_in_dir(
+    directory: str,
+    files_by_path: dict[str, dict],
+    language: str,
+) -> str | None:
+    prefix = "" if directory in {"", "."} else directory.rstrip("/") + "/"
+    matches = [
+        path
+        for path, row in files_by_path.items()
+        if row["language"] == language
+        and str(PurePosixPath(path).parent) == (directory or ".")
+    ]
+    if not matches and prefix:
+        matches = [
+            path
+            for path, row in files_by_path.items()
+            if row["language"] == language and path.startswith(prefix)
+        ]
+    if not matches:
+        return None
+    return sorted(matches, key=lambda p: (_is_test_file(p), len(p), p))[0]
+
+
+def _resolve_go_import(module: str, files_by_path: dict[str, dict]) -> str | None:
+    spec = module.strip().strip('"')
+    if not spec:
+        return None
+    dirs = sorted(
+        {
+            str(PurePosixPath(path).parent)
+            for path, row in files_by_path.items()
+            if row["language"] == "go"
+        },
+        key=lambda d: (-len(d), d),
+    )
+    for directory in dirs:
+        if directory == ".":
+            continue
+        if spec == directory or spec.endswith("/" + directory) or directory.endswith("/" + spec):
+            target = _representative_file_in_dir(directory, files_by_path, "go")
+            if target:
+                return target
+    return None
+
+
+def _resolve_rust_import(source_path: str, module: str, files_by_path: dict[str, dict]) -> str | None:
+    cleaned = module.strip().strip(";")
+    cleaned = cleaned.split(" as ", 1)[0].strip()
+    cleaned = cleaned.replace("{", "::").replace("}", "")
+    cleaned = cleaned.replace("self::", "")
+    parts = [p for p in cleaned.split("::") if p and p != "*"]
+    if not parts:
+        return None
+
+    source = PurePosixPath(source_path)
+    source_dir = source.parent
+    if source.name in {"lib.rs", "main.rs", "mod.rs"}:
+        module_dir = source_dir
+    else:
+        module_dir = source_dir
+
+    if parts[0] == "crate":
+        base = PurePosixPath("src").joinpath(*parts[1:])
+    elif parts[0] == "super":
+        rest = parts[1:]
+        base = module_dir.parent.joinpath(*rest)
+    else:
+        base = module_dir.joinpath(*parts)
+
+    candidates: list[str] = []
+    # use paths often include an item inside the module; try longest module prefix first.
+    base_parts = list(base.parts)
+    for i in range(len(base_parts), 0, -1):
+        prefix = PurePosixPath(*base_parts[:i])
+        candidates.append(str(prefix) + ".rs")
+        candidates.append(str(prefix / "mod.rs"))
+    return _first_existing(candidates, files_by_path)
+
+
+def _resolve_c_include(source_path: str, module: str, files_by_path: dict[str, dict]) -> str | None:
+    target = _resolve_path_like(source_path, module, files_by_path, C_EXTS, relative_to_source=True)
+    if target:
+        return target
+    basename = PurePosixPath(module).name
+    matches = [
+        path
+        for path in files_by_path
+        if PurePosixPath(path).name == basename
+    ]
+    return sorted(matches, key=lambda p: (len(p), p))[0] if matches else None
+
+
+def _resolve_import(imp: dict, files_by_path: dict[str, dict], module_to_paths: dict[str, list[str]]) -> str | None:
+    source = imp["source"]
+    language = imp["language"]
+    module = imp["module"] or ""
+    imported_name = imp.get("imported_name")
+    level = imp.get("level") or 0
+
+    if language == "python":
+        candidates = (
+            _resolve_relative(source, module, imported_name, level)
+            if level
+            else _resolve_absolute(module, imported_name)
+        )
+        target_module = _best_module_match(candidates, module_to_paths)
+        return module_to_paths[target_module][0] if target_module else None
+
+    if language in {"javascript", "typescript"}:
+        if module.startswith(".") or module.startswith("/"):
+            return _resolve_path_like(source, module, files_by_path, JS_TS_EXTS, relative_to_source=True)
+        # Simple support for path aliases/monorepo imports that mirror repo paths.
+        return _resolve_path_like(source, module, files_by_path, JS_TS_EXTS, relative_to_source=False)
+
+    if language == "go":
+        return _resolve_go_import(module, files_by_path)
+
+    if language == "rust":
+        return _resolve_rust_import(source, module, files_by_path)
+
+    if language in {"java", "kotlin", "csharp", "php"}:
+        candidates = [module]
+        if imported_name:
+            candidates.append(f"{module}.{imported_name}")
+        target_module = _best_module_match(candidates, module_to_paths)
+        return module_to_paths[target_module][0] if target_module else None
+
+    if language == "swift":
+        target_module = _best_module_match([module], module_to_paths)
+        return module_to_paths[target_module][0] if target_module else None
+
+    if language in {"c", "cpp"}:
+        return _resolve_c_include(source, module, files_by_path)
+
+    if language == "ruby":
+        return _resolve_path_like(source, module, files_by_path, RUBY_EXTS, relative_to_source=True)
+
+    return None
+
+
 def import_graph(repo_root: Path) -> dict:
-    """Build a Python import graph from indexed files/imports."""
+    """Build a language-agnostic import/dependency graph from indexed files/imports."""
     conn = db.connect(repo_root)
     file_rows = conn.execute(
-        "SELECT id, path, line_count FROM files WHERE language = 'python' ORDER BY path"
+        "SELECT id, path, language, line_count FROM files "
+        "WHERE language IN ({}) ORDER BY path".format(
+            ",".join("?" for _ in CODE_LANGUAGES)
+        ),
+        tuple(sorted(CODE_LANGUAGES)),
     ).fetchall()
     files_by_id = {r["id"]: dict(r) for r in file_rows}
-    module_to_path: dict[str, str] = {}
+    files_by_path = {r["path"]: dict(r) for r in file_rows}
+
+    module_to_paths: dict[str, list[str]] = defaultdict(list)
     path_to_module: dict[str, str] = {}
     for row in file_rows:
-        module = _module_for_path(row["path"])
-        if module:
-            module_to_path[module] = row["path"]
+        module = _module_for_path(row["path"], row["language"])
+        if module is not None:
+            module_to_paths[module].append(row["path"])
             path_to_module[row["path"]] = module
 
     import_rows = conn.execute(
-        "SELECT i.file_id, i.module, i.imported_name, i.alias, i.level, i.line, f.path AS source "
+        "SELECT i.file_id, i.module, i.imported_name, i.alias, i.level, i.line, "
+        "       f.path AS source, f.language AS language "
         "FROM imports i JOIN files f ON i.file_id = f.id "
-        "WHERE f.language = 'python' ORDER BY f.path, i.line"
+        "ORDER BY f.path, i.line"
     ).fetchall()
     conn.close()
 
@@ -96,41 +368,38 @@ def import_graph(repo_root: Path) -> dict:
     adjacency: dict[str, set[str]] = defaultdict(set)
     reverse: dict[str, set[str]] = defaultdict(set)
 
-    for imp in import_rows:
+    for row in import_rows:
+        imp = dict(row)
         source = imp["source"]
-        source_module = path_to_module.get(source)
-        if not source_module:
+        if source not in files_by_path:
             continue
-        level = imp["level"] or 0
-        candidates = (
-            _resolve_relative(source, imp["module"] or "", imp["imported_name"], level)
-            if level
-            else _resolve_absolute(imp["module"] or "", imp["imported_name"])
-        )
-        target_module = _best_module_match(candidates, module_to_path)
-        if not target_module:
+        target = _resolve_import(imp, files_by_path, module_to_paths)
+        if not target:
             unresolved.append(
                 {
                     "source": source,
+                    "language": imp["language"],
                     "line": imp["line"],
                     "module": imp["module"],
                     "imported_name": imp["imported_name"],
-                    "level": level,
+                    "level": imp["level"] or 0,
                 }
             )
             continue
-        target = module_to_path[target_module]
         if target == source:
             continue
+        target_row = files_by_path[target]
         edge = {
             "source": source,
-            "source_module": source_module,
+            "source_module": path_to_module.get(source),
+            "source_language": imp["language"],
             "target": target,
-            "target_module": target_module,
+            "target_module": path_to_module.get(target),
+            "target_language": target_row["language"],
             "line": imp["line"],
             "module": imp["module"],
             "imported_name": imp["imported_name"],
-            "level": level,
+            "level": imp["level"] or 0,
             "source_is_test": _is_test_file(source),
             "target_is_test": _is_test_file(target),
         }
@@ -141,6 +410,7 @@ def import_graph(repo_root: Path) -> dict:
     nodes = [
         {
             "path": r["path"],
+            "language": r["language"],
             "module": path_to_module.get(r["path"]),
             "line_count": r["line_count"],
             "is_test": _is_test_file(r["path"]),
@@ -149,6 +419,9 @@ def import_graph(repo_root: Path) -> dict:
         }
         for r in file_rows
     ]
+    languages: dict[str, int] = defaultdict(int)
+    for node in nodes:
+        languages[node["language"] or "unknown"] += 1
 
     return {
         "repo_root": str(repo_root),
@@ -156,7 +429,8 @@ def import_graph(repo_root: Path) -> dict:
         "edges": edges,
         "unresolved": unresolved,
         "summary": {
-            "python_files": len(nodes),
+            "files": len(nodes),
+            "languages": dict(sorted(languages.items())),
             "resolved_edges": len(edges),
             "unresolved_imports": len(unresolved),
         },
@@ -222,7 +496,7 @@ def check(repo_root: Path, *, max_lines: int = 1000, cycle_limit: int = 50) -> d
             {
                 "severity": "error",
                 "code": "import-cycle",
-                "message": "Python import cycle detected",
+                "message": "Import cycle detected",
                 "files": cycle,
             }
         )

--- a/repotrace/indexer.py
+++ b/repotrace/indexer.py
@@ -1,4 +1,4 @@
-"""File walking, Python AST parsing, route detection, and SQLite writes."""
+"""File walking, multi-language parsing heuristics, route detection, and SQLite writes."""
 
 from __future__ import annotations
 
@@ -7,7 +7,7 @@ import json
 import os
 import re
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable, Optional
 
@@ -36,6 +36,11 @@ EXCLUDE_DIRS = {
     "coverage",
     "site-packages",
     ".tox",
+    "target",
+    ".gradle",
+    ".build",
+    ".swiftpm",
+    "vendor",
 }
 
 LANG_BY_EXT = {
@@ -43,8 +48,29 @@ LANG_BY_EXT = {
     ".pyi": "python",
     ".ts": "typescript",
     ".tsx": "typescript",
+    ".mts": "typescript",
+    ".cts": "typescript",
     ".js": "javascript",
     ".jsx": "javascript",
+    ".mjs": "javascript",
+    ".cjs": "javascript",
+    ".go": "go",
+    ".rs": "rust",
+    ".java": "java",
+    ".kt": "kotlin",
+    ".kts": "kotlin",
+    ".swift": "swift",
+    ".c": "c",
+    ".h": "c",
+    ".cc": "cpp",
+    ".cpp": "cpp",
+    ".cxx": "cpp",
+    ".hh": "cpp",
+    ".hpp": "cpp",
+    ".hxx": "cpp",
+    ".cs": "csharp",
+    ".rb": "ruby",
+    ".php": "php",
     ".sql": "sql",
     ".md": "markdown",
     ".yaml": "yaml",
@@ -53,11 +79,97 @@ LANG_BY_EXT = {
     ".json": "json",
 }
 
+CODE_LANGUAGES = {
+    "javascript",
+    "typescript",
+    "go",
+    "rust",
+    "java",
+    "kotlin",
+    "swift",
+    "c",
+    "cpp",
+    "csharp",
+    "ruby",
+    "php",
+}
+
+CALLABLE_KINDS = {
+    "function",
+    "async_function",
+    "method",
+    "async_method",
+    "nested_function",
+    "nested_async_function",
+    "constructor",
+}
+
+CONTAINER_KINDS = {
+    "class",
+    "interface",
+    "enum",
+    "struct",
+    "trait",
+    "protocol",
+    "extension",
+    "impl",
+    "namespace",
+}
+
 # Route patterns for FastAPI / Flask / aiohttp / Sanic via regex on decorators.
 # This is a heuristic; the AST decorator pass below is the authoritative one for Python.
 ROUTE_DECORATOR_RE = re.compile(
     r"@(?P<obj>[\w\.]+)\.(?P<method>get|post|put|delete|patch|options|head|route)\s*\(",
     re.IGNORECASE,
+)
+
+CALL_RE = re.compile(
+    r"(?<![\w$])([A-Za-z_$][\w$]*(?:(?:\.|::|->)[A-Za-z_$][\w$]*)*)"
+    r"\s*(?:<[^;\n{}()]*>)?\s*\("
+)
+
+CALL_SKIP_NAMES = {
+    "if",
+    "for",
+    "while",
+    "switch",
+    "catch",
+    "with",
+    "return",
+    "throw",
+    "throws",
+    "sizeof",
+    "typeof",
+    "delete",
+    "await",
+    "yield",
+    "new",
+    "else",
+    "do",
+    "import",
+    "require",
+    "super",
+    "this",
+    "self",
+    "Self",
+    "match",
+    "guard",
+    "defer",
+    "using",
+    "namespace",
+    "class",
+    "struct",
+    "enum",
+    "interface",
+    "trait",
+    "impl",
+    "func",
+    "function",
+    "fn",
+}
+
+CONTROL_START_RE = re.compile(
+    r"^\s*(if|for|while|switch|catch|else|do|try|finally|return|throw|throws|guard|defer|using)\b"
 )
 
 
@@ -73,6 +185,16 @@ class CallName:
     callee_name: str
     callee_base: str
     callee_qualifier: Optional[str]
+
+
+@dataclass
+class SymbolCandidate:
+    name: str
+    kind: str
+    start_line: int
+    end_line: int
+    qualified_name: Optional[str] = None
+    decorators: tuple[str, ...] = field(default_factory=tuple)
 
 
 def iter_files(root: Path, use_git: bool) -> Iterable[Path]:
@@ -98,6 +220,85 @@ def _line_count(path: Path) -> int:
             return sum(1 for _ in f)
     except Exception:
         return 0
+
+
+def _read_source(path: Path) -> str | None:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        return None
+
+
+def _insert_import(
+    conn,
+    file_id: int,
+    module: str,
+    imported_name: str | None = None,
+    alias: str | None = None,
+    level: int = 0,
+    line: int | None = None,
+) -> None:
+    conn.execute(
+        "INSERT INTO imports(file_id, module, imported_name, alias, level, line) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (file_id, module, imported_name, alias, level, line),
+    )
+
+
+def _insert_symbol(
+    conn,
+    file_id: int,
+    candidate: SymbolCandidate,
+    parent_id: int | None = None,
+) -> int:
+    cur = conn.execute(
+        "INSERT INTO symbols(name, qualified_name, kind, file_id, parent_id, "
+        "start_line, end_line, docstring, decorators) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            candidate.name,
+            candidate.qualified_name or candidate.name,
+            candidate.kind,
+            file_id,
+            parent_id,
+            candidate.start_line,
+            candidate.end_line,
+            "",
+            json.dumps(list(candidate.decorators)),
+        ),
+    )
+    return int(cur.lastrowid)
+
+
+def _insert_call(conn, file_id: int, caller_symbol_id: int | None, call_name: CallName, line: int) -> None:
+    conn.execute(
+        "INSERT INTO calls(caller_symbol_id, callee_name, callee_base, "
+        "callee_qualifier, line, file_id) VALUES (?, ?, ?, ?, ?, ?)",
+        (
+            caller_symbol_id,
+            call_name.callee_name,
+            call_name.callee_base,
+            call_name.callee_qualifier,
+            line,
+            file_id,
+        ),
+    )
+
+
+def _insert_route(
+    conn,
+    file_id: int,
+    framework: str,
+    method: str,
+    path: str,
+    handler_symbol_id: int | None,
+    line: int,
+) -> None:
+    conn.execute(
+        "INSERT INTO routes(file_id, framework, method, path, "
+        "handler_symbol_id, line) VALUES (?, ?, ?, ?, ?, ?)",
+        (file_id, framework, method.upper(), path, handler_symbol_id, line),
+    )
 
 
 def _decorators_to_strs(decorators: list[ast.expr]) -> list[str]:
@@ -143,14 +344,9 @@ def _route_from_decorator(dec: ast.expr) -> Optional[tuple[str, str, str]]:
     return (framework, method.upper(), path_val)
 
 
-def _index_python(
-    conn,
-    file_id: int,
-    path: Path,
-) -> None:
-    try:
-        source = path.read_text(encoding="utf-8", errors="replace")
-    except Exception:
+def _index_python(conn, file_id: int, path: Path) -> None:
+    source = _read_source(path)
+    if source is None:
         return
     try:
         tree = ast.parse(source, filename=str(path))
@@ -161,19 +357,11 @@ def _index_python(
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             for alias in node.names:
-                conn.execute(
-                    "INSERT INTO imports(file_id, module, imported_name, alias, level, line) "
-                    "VALUES (?, ?, ?, ?, ?, ?)",
-                    (file_id, alias.name, None, alias.asname, 0, node.lineno),
-                )
+                _insert_import(conn, file_id, alias.name, None, alias.asname, 0, node.lineno)
         elif isinstance(node, ast.ImportFrom):
             module = node.module or ""
             for alias in node.names:
-                conn.execute(
-                    "INSERT INTO imports(file_id, module, imported_name, alias, level, line) "
-                    "VALUES (?, ?, ?, ?, ?, ?)",
-                    (file_id, module, alias.name, alias.asname, node.level, node.lineno),
-                )
+                _insert_import(conn, file_id, module, alias.name, alias.asname, node.level, node.lineno)
 
     # Symbols + nested + calls
     def walk_body(
@@ -222,28 +410,13 @@ def _index_python(
                     route = _route_from_decorator(dec)
                     if route:
                         framework, method, path_val = route
-                        conn.execute(
-                            "INSERT INTO routes(file_id, framework, method, path, "
-                            "handler_symbol_id, line) VALUES (?, ?, ?, ?, ?, ?)",
-                            (file_id, framework, method, path_val, sym_id, node.lineno),
-                        )
+                        _insert_route(conn, file_id, framework, method, path_val, sym_id, node.lineno)
 
                 # Calls inside this symbol body, excluding nested defs/classes so
                 # local helpers do not get attributed to the outer function too.
                 if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
                     for call_node, call_name in _calls_in_body(node.body):
-                        conn.execute(
-                            "INSERT INTO calls(caller_symbol_id, callee_name, callee_base, "
-                            "callee_qualifier, line, file_id) VALUES (?, ?, ?, ?, ?, ?)",
-                            (
-                                sym_id,
-                                call_name.callee_name,
-                                call_name.callee_base,
-                                call_name.callee_qualifier,
-                                call_node.lineno,
-                                file_id,
-                            ),
-                        )
+                        _insert_call(conn, file_id, sym_id, call_name, call_node.lineno)
 
                 # Recurse for nested defs / methods
                 walk_body(node.body, sym_id, kind, qname)
@@ -287,8 +460,16 @@ def _call_name(func: ast.expr) -> Optional[CallName]:
     parts = _expr_name_parts(func)
     if not parts:
         return None
+    return _call_name_from_parts(parts)
+
+
+def _call_name_from_parts(parts: list[str]) -> Optional[CallName]:
+    if not parts:
+        return None
     callee_name = ".".join(parts)
     callee_base = parts[-1].removesuffix("()")
+    if not callee_base or callee_base in CALL_SKIP_NAMES:
+        return None
     qualifier = ".".join(parts[:-1]) or None
     return CallName(callee_name, callee_base, qualifier)
 
@@ -312,6 +493,508 @@ def _expr_name_parts(expr: ast.expr) -> Optional[list[str]]:
     if isinstance(expr, ast.Subscript):
         return _expr_name_parts(expr.value)
     return None
+
+
+def _strip_line_comment(line: str, language: str) -> str:
+    stripped = line.lstrip()
+    if language in {"python", "ruby"}:
+        return line.split("#", 1)[0]
+    if language == "sql":
+        return line.split("--", 1)[0]
+    if language == "php" and stripped.startswith("#"):
+        return ""
+    return line.split("//", 1)[0]
+
+
+def _find_block_end(lines: list[str], start_line: int, language: str) -> int:
+    """Best-effort brace block end for C-like languages."""
+    depth = 0
+    saw_open = False
+    for idx in range(start_line - 1, len(lines)):
+        text = _strip_line_comment(lines[idx], language)
+        for ch in text:
+            if ch == "{":
+                depth += 1
+                saw_open = True
+            elif ch == "}":
+                depth -= 1
+                if saw_open and depth <= 0:
+                    return idx + 1
+        if saw_open and depth <= 0:
+            return idx + 1
+        if not saw_open and idx + 1 > start_line + 3:
+            break
+    return start_line
+
+
+def _decorators_before(lines: list[str], line_no: int) -> tuple[str, ...]:
+    decorators: list[str] = []
+    idx = line_no - 2
+    while idx >= 0:
+        stripped = lines[idx].strip()
+        if not stripped:
+            break
+        if stripped.startswith("@"):  # Java/Kotlin/Spring, C# attributes are handled separately.
+            decorators.append(stripped)
+            idx -= 1
+            continue
+        break
+    decorators.reverse()
+    return tuple(decorators)
+
+
+def _route_from_text(text: str, language: str) -> tuple[str, str, str] | None:
+    stripped = text.strip()
+
+    # Express/Fastify/Koa-like APIs: app.get('/path', handler)
+    m = re.search(
+        r"\b(?:app|router|server|route)\.(get|post|put|delete|patch|options|head|all|use)"
+        r"\s*\(\s*['\"]([^'\"]+)",
+        stripped,
+        re.IGNORECASE,
+    )
+    if m:
+        method = m.group(1).upper()
+        if method in {"ALL", "USE"}:
+            method = "*"
+        return ("javascript-router", method, m.group(2))
+
+    # Go stdlib/net-http and common routers.
+    m = re.search(r"\bHandleFunc\s*\(\s*['\"]([^'\"]+)", stripped)
+    if m:
+        return ("go-net-http", "*", m.group(1))
+
+    # Java/Kotlin/Spring annotations.
+    annotation_methods = {
+        "GetMapping": "GET",
+        "PostMapping": "POST",
+        "PutMapping": "PUT",
+        "DeleteMapping": "DELETE",
+        "PatchMapping": "PATCH",
+    }
+    m = re.search(r"@(GetMapping|PostMapping|PutMapping|DeleteMapping|PatchMapping)\s*\((.*)\)", stripped)
+    if m:
+        path = _first_string_literal(m.group(2))
+        if path:
+            return ("spring", annotation_methods[m.group(1)], path)
+    m = re.search(r"@RequestMapping\s*\((.*)\)", stripped)
+    if m:
+        args = m.group(1)
+        path = _first_string_literal(args)
+        method = "*"
+        method_match = re.search(r"RequestMethod\.([A-Z]+)", args)
+        if method_match:
+            method = method_match.group(1)
+        if path:
+            return ("spring", method, path)
+
+    # C# ASP.NET attributes.
+    m = re.search(r"\[(HttpGet|HttpPost|HttpPut|HttpDelete|HttpPatch)(?:\((.*)\))?\]", stripped)
+    if m:
+        method = m.group(1).removeprefix("Http").upper()
+        path = _first_string_literal(m.group(2) or "") or ""
+        return ("aspnet", method, path)
+
+    return None
+
+
+def _first_string_literal(text: str) -> str | None:
+    m = re.search(r"['\"]([^'\"]+)['\"]", text)
+    return m.group(1) if m else None
+
+
+def _generic_imports(language: str, lines: list[str]) -> list[tuple[str, str | None, str | None, int, int]]:
+    imports: list[tuple[str, str | None, str | None, int, int]] = []
+    in_go_block = False
+
+    for line_no, line in enumerate(lines, start=1):
+        stripped = line.strip()
+        if not stripped:
+            continue
+
+        if language in {"javascript", "typescript"}:
+            m = re.match(r"import\s+(?:type\s+)?(?:.+?\s+from\s+)?['\"]([^'\"]+)['\"]", stripped)
+            if not m:
+                m = re.match(r"export\s+.+?\s+from\s+['\"]([^'\"]+)['\"]", stripped)
+            if m:
+                module = m.group(1)
+                named = re.search(r"\{([^}]+)\}", stripped)
+                if named:
+                    for part in named.group(1).split(","):
+                        name = part.strip().split(" as ", 1)[0].strip()
+                        if name:
+                            imports.append((module, name, None, 0, line_no))
+                else:
+                    imports.append((module, None, None, 0, line_no))
+            for req in re.finditer(r"require\s*\(\s*['\"]([^'\"]+)['\"]\s*\)", stripped):
+                imports.append((req.group(1), None, None, 0, line_no))
+
+        elif language == "go":
+            if in_go_block:
+                if stripped.startswith(")"):
+                    in_go_block = False
+                    continue
+                m = re.search(r"(?:[\w\.]+\s+)?['\"]([^'\"]+)['\"]", stripped)
+                if m:
+                    imports.append((m.group(1), None, None, 0, line_no))
+                continue
+            if re.match(r"import\s*\(", stripped):
+                in_go_block = True
+                continue
+            m = re.match(r"import\s+(?:[\w\.]+\s+)?['\"]([^'\"]+)['\"]", stripped)
+            if m:
+                imports.append((m.group(1), None, None, 0, line_no))
+
+        elif language == "rust":
+            m = re.match(r"(?:pub\s+)?use\s+(.+?);", stripped)
+            if m:
+                imports.append((m.group(1).strip(), None, None, 0, line_no))
+            m = re.match(r"mod\s+([A-Za-z_][\w]*);", stripped)
+            if m:
+                imports.append((m.group(1), None, None, 0, line_no))
+
+        elif language in {"java", "kotlin"}:
+            m = re.match(r"import\s+(?:static\s+)?([\w.*]+);?", stripped)
+            if m:
+                imports.append((m.group(1), None, None, 0, line_no))
+
+        elif language == "swift":
+            m = re.match(r"import\s+([A-Za-z_][\w.]*)", stripped)
+            if m:
+                imports.append((m.group(1), None, None, 0, line_no))
+
+        elif language in {"c", "cpp", "csharp"}:
+            m = re.match(r"#include\s+[<\"]([^>\"]+)[>\"]", stripped)
+            if m:
+                imports.append((m.group(1), None, None, 0, line_no))
+            m = re.match(r"using\s+([\w.]+);", stripped)
+            if m:
+                imports.append((m.group(1), None, None, 0, line_no))
+
+        elif language == "ruby":
+            m = re.match(r"require(?:_relative)?\s+['\"]([^'\"]+)['\"]", stripped)
+            if m:
+                imports.append((m.group(1), None, None, 0, line_no))
+
+        elif language == "php":
+            m = re.match(r"use\s+([^;]+);", stripped)
+            if m:
+                imports.append((m.group(1).replace("\\", "."), None, None, 0, line_no))
+            m = re.match(r"(?:require|include)(?:_once)?\s*[\( ]\s*['\"]([^'\"]+)['\"]", stripped)
+            if m:
+                imports.append((m.group(1), None, None, 0, line_no))
+
+    return imports
+
+
+def _generic_symbols(language: str, lines: list[str]) -> list[SymbolCandidate]:
+    symbols: list[SymbolCandidate] = []
+
+    for line_no, line in enumerate(lines, start=1):
+        stripped = _strip_line_comment(line, language).strip()
+        if not stripped or stripped.startswith(("//", "/*", "*")):
+            continue
+
+        decorators = _decorators_before(lines, line_no)
+
+        if language in {"javascript", "typescript"}:
+            _add_js_ts_symbol(symbols, lines, language, stripped, line_no, decorators)
+        elif language == "go":
+            _add_go_symbol(symbols, lines, language, stripped, line_no)
+        elif language == "rust":
+            _add_rust_symbol(symbols, lines, language, stripped, line_no)
+        elif language == "java":
+            _add_java_symbol(symbols, lines, language, stripped, line_no, decorators)
+        elif language == "kotlin":
+            _add_kotlin_symbol(symbols, lines, language, stripped, line_no, decorators)
+        elif language == "swift":
+            _add_swift_symbol(symbols, lines, language, stripped, line_no)
+        elif language in {"c", "cpp", "csharp"}:
+            _add_c_like_symbol(symbols, lines, language, stripped, line_no)
+        elif language == "ruby":
+            _add_ruby_symbol(symbols, lines, language, stripped, line_no)
+        elif language == "php":
+            _add_php_symbol(symbols, lines, language, stripped, line_no)
+
+    return _qualify_nested_symbols(symbols)
+
+
+def _add_candidate(
+    symbols: list[SymbolCandidate],
+    lines: list[str],
+    language: str,
+    name: str,
+    kind: str,
+    line_no: int,
+    decorators: tuple[str, ...] = (),
+    qualified_name: str | None = None,
+) -> None:
+    symbols.append(
+        SymbolCandidate(
+            name=name,
+            qualified_name=qualified_name,
+            kind=kind,
+            start_line=line_no,
+            end_line=_find_block_end(lines, line_no, language),
+            decorators=decorators,
+        )
+    )
+
+
+def _add_js_ts_symbol(
+    symbols: list[SymbolCandidate],
+    lines: list[str],
+    language: str,
+    stripped: str,
+    line_no: int,
+    decorators: tuple[str, ...],
+) -> None:
+    m = re.match(r"(?:export\s+)?(?:default\s+)?(?:abstract\s+)?class\s+([A-Za-z_$][\w$]*)", stripped)
+    if m:
+        _add_candidate(symbols, lines, language, m.group(1), "class", line_no, decorators)
+        return
+    m = re.match(r"(?:export\s+)?(?:interface|type)\s+([A-Za-z_$][\w$]*)", stripped)
+    if m:
+        _add_candidate(symbols, lines, language, m.group(1), "interface" if "interface" in stripped else "type", line_no)
+        return
+    m = re.match(r"(?:export\s+)?enum\s+([A-Za-z_$][\w$]*)", stripped)
+    if m:
+        _add_candidate(symbols, lines, language, m.group(1), "enum", line_no)
+        return
+    m = re.match(r"(?:export\s+)?(?:default\s+)?(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\s*\(", stripped)
+    if m:
+        kind = "async_function" if "async" in stripped.split("function", 1)[0].split() else "function"
+        _add_candidate(symbols, lines, language, m.group(1), kind, line_no)
+        return
+    m = re.match(
+        r"(?:export\s+)?(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s*)?(?:function\b|\([^)]*\)\s*=>|[A-Za-z_$][\w$]*\s*=>)",
+        stripped,
+    )
+    if m:
+        kind = "async_function" if "async" in stripped else "function"
+        _add_candidate(symbols, lines, language, m.group(1), kind, line_no)
+        return
+    if not CONTROL_START_RE.match(stripped):
+        m = re.match(r"(?:public\s+|private\s+|protected\s+|static\s+|async\s+|override\s+|readonly\s+)*([A-Za-z_$][\w$]*)\s*\([^)]*\)\s*[:\w<>\[\], ?|&]*\s*\{", stripped)
+        if m and m.group(1) not in CALL_SKIP_NAMES:
+            kind = "async_method" if "async" in stripped.split(m.group(1), 1)[0].split() else "method"
+            _add_candidate(symbols, lines, language, m.group(1), kind, line_no, decorators)
+
+
+def _add_go_symbol(symbols: list[SymbolCandidate], lines: list[str], language: str, stripped: str, line_no: int) -> None:
+    m = re.match(r"func\s*\(([^)]+)\)\s*([A-Za-z_][\w]*)\s*\(", stripped)
+    if m:
+        receiver = m.group(1).strip().split()[-1].lstrip("*")
+        name = m.group(2)
+        _add_candidate(symbols, lines, language, name, "method", line_no, qualified_name=f"{receiver}.{name}")
+        return
+    m = re.match(r"func\s+([A-Za-z_][\w]*)\s*\(", stripped)
+    if m:
+        _add_candidate(symbols, lines, language, m.group(1), "function", line_no)
+        return
+    m = re.match(r"type\s+([A-Za-z_][\w]*)\s+(struct|interface)\b", stripped)
+    if m:
+        _add_candidate(symbols, lines, language, m.group(1), m.group(2), line_no)
+
+
+def _add_rust_symbol(symbols: list[SymbolCandidate], lines: list[str], language: str, stripped: str, line_no: int) -> None:
+    m = re.match(r"(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?fn\s+([A-Za-z_][\w]*)\s*(?:<[^>]+>)?\s*\(", stripped)
+    if m:
+        kind = "async_function" if "async" in stripped.split("fn", 1)[0].split() else "function"
+        _add_candidate(symbols, lines, language, m.group(1), kind, line_no)
+        return
+    m = re.match(r"(?:pub\s+)?(struct|enum|trait)\s+([A-Za-z_][\w]*)", stripped)
+    if m:
+        _add_candidate(symbols, lines, language, m.group(2), m.group(1), line_no)
+        return
+    m = re.match(r"impl(?:\s*<[^>]+>)?\s+([A-Za-z_][\w]*(?:::[A-Za-z_][\w]*)*)", stripped)
+    if m:
+        _add_candidate(symbols, lines, language, m.group(1).split("::")[-1], "impl", line_no, qualified_name=m.group(1).replace("::", "."))
+
+
+def _add_java_symbol(
+    symbols: list[SymbolCandidate],
+    lines: list[str],
+    language: str,
+    stripped: str,
+    line_no: int,
+    decorators: tuple[str, ...],
+) -> None:
+    m = re.match(r"(?:public\s+|private\s+|protected\s+|abstract\s+|final\s+|static\s+)*(class|interface|enum|record)\s+([A-Za-z_][\w]*)", stripped)
+    if m:
+        kind = "class" if m.group(1) == "record" else m.group(1)
+        _add_candidate(symbols, lines, language, m.group(2), kind, line_no, decorators)
+        return
+    if CONTROL_START_RE.match(stripped) or stripped.startswith("@"):
+        return
+    m = re.match(
+        r"(?:public\s+|private\s+|protected\s+|static\s+|final\s+|synchronized\s+|abstract\s+|native\s+)*"
+        r"(?:<[^>]+>\s*)?(?:[\w.$<>\[\], ?]+\s+)?([A-Za-z_][\w]*)\s*\([^;{}]*\)\s*(?:throws\s+[\w., ]+\s*)?\{?",
+        stripped,
+    )
+    if m and m.group(1) not in CALL_SKIP_NAMES:
+        _add_candidate(symbols, lines, language, m.group(1), "method", line_no, decorators)
+
+
+def _add_kotlin_symbol(
+    symbols: list[SymbolCandidate],
+    lines: list[str],
+    language: str,
+    stripped: str,
+    line_no: int,
+    decorators: tuple[str, ...],
+) -> None:
+    m = re.match(r"(?:public\s+|private\s+|internal\s+|open\s+|data\s+|sealed\s+|abstract\s+)*(class|interface|object|enum\s+class)\s+([A-Za-z_][\w]*)", stripped)
+    if m:
+        kind = "enum" if m.group(1).startswith("enum") else ("class" if m.group(1) == "object" else m.group(1))
+        _add_candidate(symbols, lines, language, m.group(2), kind, line_no, decorators)
+        return
+    m = re.match(r"(?:public\s+|private\s+|internal\s+|suspend\s+|inline\s+|operator\s+|override\s+)*fun\s+(?:[A-Za-z_][\w]*\.)?([A-Za-z_][\w]*)\s*\(", stripped)
+    if m:
+        kind = "async_function" if "suspend" in stripped.split("fun", 1)[0].split() else "function"
+        _add_candidate(symbols, lines, language, m.group(1), kind, line_no, decorators)
+
+
+def _add_swift_symbol(symbols: list[SymbolCandidate], lines: list[str], language: str, stripped: str, line_no: int) -> None:
+    m = re.match(r"(?:public\s+|private\s+|internal\s+|open\s+|final\s+)*(class|struct|enum|protocol|extension)\s+([A-Za-z_][\w]*)", stripped)
+    if m:
+        kind = "class" if m.group(1) == "extension" else m.group(1)
+        _add_candidate(symbols, lines, language, m.group(2), kind, line_no)
+        return
+    m = re.match(r"(?:public\s+|private\s+|internal\s+|static\s+|class\s+|mutating\s+)*func\s+([A-Za-z_][\w]*)\s*\(", stripped)
+    if m:
+        _add_candidate(symbols, lines, language, m.group(1), "function", line_no)
+
+
+def _add_c_like_symbol(symbols: list[SymbolCandidate], lines: list[str], language: str, stripped: str, line_no: int) -> None:
+    m = re.match(r"(?:public\s+|private\s+|protected\s+|internal\s+|static\s+|abstract\s+|sealed\s+|partial\s+)*(class|struct|interface|enum|namespace)\s+([A-Za-z_][\w]*)", stripped)
+    if m:
+        _add_candidate(symbols, lines, language, m.group(2), m.group(1), line_no)
+        return
+    if CONTROL_START_RE.match(stripped) or stripped.startswith("#"):
+        return
+    m = re.match(
+        r"(?:public\s+|private\s+|protected\s+|internal\s+|static\s+|virtual\s+|override\s+|async\s+|inline\s+|constexpr\s+|extern\s+)*"
+        r"[A-Za-z_][\w:<>,~*&\s\[\]]+\s+([A-Za-z_~][\w~]*)\s*\([^;{}]*\)\s*(?:const\s*)?\{?",
+        stripped,
+    )
+    if m and m.group(1) not in CALL_SKIP_NAMES:
+        kind = "async_function" if "async" in stripped.split(m.group(1), 1)[0].split() else "function"
+        _add_candidate(symbols, lines, language, m.group(1), kind, line_no)
+
+
+def _add_ruby_symbol(symbols: list[SymbolCandidate], lines: list[str], language: str, stripped: str, line_no: int) -> None:
+    m = re.match(r"class\s+([A-Z][\w:]*)", stripped)
+    if m:
+        _add_candidate(symbols, lines, language, m.group(1).split("::")[-1], "class", line_no, qualified_name=m.group(1).replace("::", "."))
+        return
+    m = re.match(r"def\s+(?:self\.)?([A-Za-z_]\w*[!?=]?)", stripped)
+    if m:
+        _add_candidate(symbols, lines, language, m.group(1), "function", line_no)
+
+
+def _add_php_symbol(symbols: list[SymbolCandidate], lines: list[str], language: str, stripped: str, line_no: int) -> None:
+    m = re.match(r"(?:abstract\s+|final\s+)?(class|interface|trait|enum)\s+([A-Za-z_][\w]*)", stripped)
+    if m:
+        _add_candidate(symbols, lines, language, m.group(2), m.group(1), line_no)
+        return
+    m = re.match(r"(?:public\s+|private\s+|protected\s+|static\s+|final\s+|abstract\s+)*function\s+([A-Za-z_][\w]*)\s*\(", stripped)
+    if m:
+        _add_candidate(symbols, lines, language, m.group(1), "function", line_no)
+
+
+def _qualify_nested_symbols(symbols: list[SymbolCandidate]) -> list[SymbolCandidate]:
+    ordered = sorted(symbols, key=lambda s: (s.start_line, -(s.end_line or s.start_line)))
+    for idx, sym in enumerate(ordered):
+        if sym.qualified_name and sym.qualified_name != sym.name:
+            continue
+        parents = [
+            p
+            for p in ordered[:idx]
+            if p.kind in CONTAINER_KINDS
+            and p.start_line < sym.start_line
+            and (p.end_line or p.start_line) >= (sym.end_line or sym.start_line)
+        ]
+        if parents and sym.kind in CALLABLE_KINDS:
+            parent = max(parents, key=lambda p: p.start_line)
+            sym.qualified_name = f"{parent.qualified_name or parent.name}.{sym.name}"
+    return ordered
+
+
+def _generic_calls_in_range(lines: list[str], language: str, start_line: int, end_line: int, current_name: str) -> list[tuple[int, CallName]]:
+    calls: list[tuple[int, CallName]] = []
+    for line_no in range(start_line, min(end_line, len(lines)) + 1):
+        line = _strip_line_comment(lines[line_no - 1], language)
+        if not line.strip() or line.strip().startswith(("import ", "package ", "use ", "#include")):
+            continue
+        for match in CALL_RE.finditer(line):
+            raw = match.group(1)
+            parts = [p for p in re.split(r"\.|::|->", raw) if p]
+            if not parts:
+                continue
+            base = parts[-1]
+            prefix = line[: match.start()].rstrip()
+            if base in CALL_SKIP_NAMES or (line_no == start_line and base == current_name):
+                continue
+            if prefix.endswith(("function", "func", "fn", "def")):
+                continue
+            call_name = _call_name_from_parts(parts)
+            if call_name:
+                calls.append((line_no, call_name))
+    return calls
+
+
+def _index_generic(conn, file_id: int, path: Path, language: str) -> None:
+    source = _read_source(path)
+    if source is None:
+        return
+    lines = source.splitlines()
+
+    for module, imported_name, alias, level, line in _generic_imports(language, lines):
+        _insert_import(conn, file_id, module, imported_name, alias, level, line)
+
+    symbols = _generic_symbols(language, lines)
+    symbol_ids: dict[int, int] = {}
+    inserted: list[tuple[SymbolCandidate, int]] = []
+
+    for idx, candidate in enumerate(symbols):
+        parent_id = None
+        parents = [
+            (parent, sym_id)
+            for parent, sym_id in inserted
+            if parent.start_line < candidate.start_line
+            and (parent.end_line or parent.start_line) >= (candidate.end_line or candidate.start_line)
+        ]
+        if parents:
+            parent_id = max(parents, key=lambda item: item[0].start_line)[1]
+        sym_id = _insert_symbol(conn, file_id, candidate, parent_id)
+        symbol_ids[idx] = sym_id
+        inserted.append((candidate, sym_id))
+
+        for dec in candidate.decorators:
+            route = _route_from_text(dec, language)
+            if route:
+                framework, method, route_path = route
+                _insert_route(conn, file_id, framework, method, route_path, sym_id, candidate.start_line)
+
+        if candidate.kind in CALLABLE_KINDS:
+            for line_no, call_name in _generic_calls_in_range(
+                lines,
+                language,
+                candidate.start_line,
+                candidate.end_line,
+                candidate.name,
+            ):
+                _insert_call(conn, file_id, sym_id, call_name, line_no)
+
+    for line_no, line in enumerate(lines, start=1):
+        route = _route_from_text(line, language)
+        if route:
+            framework, method, route_path = route
+            # Decorator-backed routes were already inserted with a handler id.
+            if line.strip().startswith("@"):
+                continue
+            _insert_route(conn, file_id, framework, method, route_path, None, line_no)
 
 
 def index_repo(repo_root: Path, *, reset: bool = False, verbose: bool = False) -> dict:
@@ -367,16 +1050,20 @@ def index_repo(repo_root: Path, *, reset: bool = False, verbose: bool = False) -
         file_id = cur.lastrowid
         files_indexed += 1
 
+        before_syms = conn.execute("SELECT COUNT(*) FROM symbols").fetchone()[0]
+        before_imps = conn.execute("SELECT COUNT(*) FROM imports").fetchone()[0]
+        before_calls = conn.execute("SELECT COUNT(*) FROM calls").fetchone()[0]
+        before_routes = conn.execute("SELECT COUNT(*) FROM routes").fetchone()[0]
+
         if lang == "python":
-            before_syms = conn.execute("SELECT COUNT(*) FROM symbols").fetchone()[0]
-            before_imps = conn.execute("SELECT COUNT(*) FROM imports").fetchone()[0]
-            before_calls = conn.execute("SELECT COUNT(*) FROM calls").fetchone()[0]
-            before_routes = conn.execute("SELECT COUNT(*) FROM routes").fetchone()[0]
             _index_python(conn, file_id, path)
-            symbols_count += conn.execute("SELECT COUNT(*) FROM symbols").fetchone()[0] - before_syms
-            imports_count += conn.execute("SELECT COUNT(*) FROM imports").fetchone()[0] - before_imps
-            calls_count += conn.execute("SELECT COUNT(*) FROM calls").fetchone()[0] - before_calls
-            routes_count += conn.execute("SELECT COUNT(*) FROM routes").fetchone()[0] - before_routes
+        elif lang in CODE_LANGUAGES:
+            _index_generic(conn, file_id, path, lang)
+
+        symbols_count += conn.execute("SELECT COUNT(*) FROM symbols").fetchone()[0] - before_syms
+        imports_count += conn.execute("SELECT COUNT(*) FROM imports").fetchone()[0] - before_imps
+        calls_count += conn.execute("SELECT COUNT(*) FROM calls").fetchone()[0] - before_calls
+        routes_count += conn.execute("SELECT COUNT(*) FROM routes").fetchone()[0] - before_routes
 
     conn.execute(
         "INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)",


### PR DESCRIPTION
Closes #1

Extends repotrace's indexer beyond Python to cover TS, JS, Go, Rust, Java, Kotlin, Swift, C, C++, C#, Ruby, PHP via regex-based heuristics. Python remains AST-authoritative. No new runtime dependencies.

Diff: +1,046 / -85 across repotrace/indexer.py and repotrace/deps.py.
